### PR TITLE
chore(harness): ignore local-only operator harness paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ yarn-error.log*
 .agent/
 .gemini/
 
+# Local-only operator harness: never enter git
+.claude/
+.mayank/
+CLAUDE.md
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary

Adds three patterns to `.gitignore` so that the local-only `steeltroops-cto` operator harness (`.claude/`, `.mayank/`, `CLAUDE.md`) cannot accidentally enter git history. Mirrors the existing precedent set by `.kiro/`, `.agent/`, `.gemini/` (lines 36-38).

This is the entire content of the PR: 4 lines in `.gitignore`. The 60+ files of harness content (rules, skills, agents, output styles, personal architecture canon, ADRs, decisions trail) live local-only and never enter git.

## Why

The harness is operator-only infrastructure: rules that Claude reads, decision records that the operator writes, personal architecture canon. None of it is part of the public deliverable (a browser-based Kerr black hole simulation). Other AI/operator tooling directories (`.kiro/`, `.agent/`, `.gemini/`) already follow this pattern; this commit extends it to the new harness paths.

## Alternatives rejected

- **Commit the harness content publicly** — rejected. The harness embeds personal decision context, voice preferences, and operator workflow. It belongs to the operator, not the public repo.
- **Use a separate operator repo** — rejected. Operator harness needs to sit alongside the project to import rules into `CLAUDE.md` via `@.claude/rules/...` syntax. Splitting into another repo breaks Claude Code's auto-import.
- **Single `.gitignore` line `.[a-z]*/`** — rejected. Too broad; would catch `.github/`, `.next/`, etc. The explicit per-directory pattern matches existing precedent.

## Risk

None. Adding gitignore patterns cannot break anything; it only prevents future commits from including those paths. If the harness paths were already tracked, this PR would not retroactively untrack them, but they aren't tracked, so this is purely preventative.

## Rollback

Single revert (`git revert <sha>`). Removes the three patterns. Harness paths become trackable again, but they remain untracked because no one is adding them to git.

## Tests

- `bun run test` — passes (326/326). Pre-push hook ran and passed.
- No runtime code changed; no new tests needed.

## What this PR does NOT include

- **The harness content itself.** That lives in the operator's local working tree at `.claude/` (16 rules + 6 skills + 4 agents + output style + settings.json), `.mayank/` (10 numbered canon docs + 13 ADRs + decisions index + CHANGELOG-rules + physics/performance/seo subfolders + superpowers/specs+plans), and `CLAUDE.md` (operator charter). None of that enters git.
- **CI workflows for the rules.** Rule enforcement is honor-system this round; each rule ships with a manual check command (`bun run physics:regress`, `bun run seo:check`, etc.). CI promotion is a future ADR.
- **Committed governance** (CONTRIBUTING.md, SECURITY.md, CHANGELOG.md, CODEOWNERS, PR templates). Operator override; future ADR.