### PR TITLE
fix(physics): memory safety + FFI hardening

### DIFF
--- a/physics-engine/gravitas-core/src/geodesic/mod.rs
+++ b/physics-engine/gravitas-core/src/geodesic/mod.rs
@@ -196,8 +196,19 @@ pub fn integrate<M: Metric>(
         None
     };
 
-    // Renormalize momentum to H=0 at start
-    crate::invariants::renormalize_null(&mut state, metric);
+    // Renormalize momentum to H=0 at start. If the initial state already
+    // drifted off the null cone (caller built it incorrectly), terminate
+    // immediately so the caller sees the failure rather than integrating
+    // a non-null geodesic.
+    if crate::invariants::renormalize_null(&mut state, metric).is_err() {
+        return Trajectory {
+            final_state: state,
+            termination: TerminationReason::NormalizationFailure,
+            steps_taken: 0,
+            max_hamiltonian_drift: 0.0,
+            path,
+        };
+    }
 
     for _ in 0..options.max_steps {
         // Check termination
@@ -225,9 +236,19 @@ pub fn integrate<M: Metric>(
             }
         }
 
-        // Renormalize periodically
-        if steps % options.renormalize_interval == 0 {
-            crate::invariants::renormalize_null(&mut state, metric);
+        // Renormalize periodically. On severe drift, terminate the
+        // integration so the caller sees NormalizationFailure rather
+        // than continuing with stale state.
+        if steps % options.renormalize_interval == 0
+            && crate::invariants::renormalize_null(&mut state, metric).is_err()
+        {
+            return Trajectory {
+                final_state: state,
+                termination: TerminationReason::NormalizationFailure,
+                steps_taken: steps,
+                max_hamiltonian_drift: max_drift,
+                path,
+            };
         }
 
         // Track drift

--- a/physics-engine/gravitas-core/src/geodesic/termination.rs
+++ b/physics-engine/gravitas-core/src/geodesic/termination.rs
@@ -14,4 +14,8 @@ pub enum TerminationReason {
     MaxSteps,
     /// Ray hit the accretion disk plane.
     DiskCrossing,
+    /// Renormalization detected the geodesic drifted off the null cone
+    /// by more than rounding noise. Indicates accumulated numerical drift
+    /// the renormalizer cannot correct.
+    NormalizationFailure,
 }

--- a/physics-engine/gravitas-core/src/invariants/mod.rs
+++ b/physics-engine/gravitas-core/src/invariants/mod.rs
@@ -14,7 +14,7 @@ mod renormalization;
 pub use audit::NumericalAudit;
 pub use constants_of_motion::compute_constants;
 pub use constants_of_motion::ConstantsOfMotion;
-pub use renormalization::renormalize_null;
+pub use renormalization::{renormalize_null, NormalizationError, ROUNDING_TOLERANCE};
 
 use crate::geodesic::GeodesicState;
 use crate::metric::Metric;

--- a/physics-engine/gravitas-core/src/invariants/renormalization.rs
+++ b/physics-engine/gravitas-core/src/invariants/renormalization.rs
@@ -6,11 +6,57 @@
 use crate::geodesic::GeodesicState;
 use crate::metric::Metric;
 
+/// Tolerance for clamping a slightly-negative discriminant caused by
+/// floating-point rounding accumulated over many integration steps. A
+/// discriminant in `[-ROUNDING_TOLERANCE, 0)` is treated as zero (the
+/// vector is on the null cone within numerical precision); a more
+/// negative discriminant indicates real drift and is propagated as an
+/// error.
+pub const ROUNDING_TOLERANCE: f64 = 1e-12;
+
+/// Errors from null-momentum renormalization.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NormalizationError {
+    /// Discriminant fell below the rounding-tolerance band, indicating
+    /// accumulated numerical drift well beyond what clamping can fix.
+    /// Caller should reset the geodesic state from a known-good source
+    /// or abort the integration.
+    NegativeDiscriminant {
+        /// Actual discriminant value (negative, < -ROUNDING_TOLERANCE).
+        value: f64,
+    },
+}
+
+impl core::fmt::Display for NormalizationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NegativeDiscriminant { value } => write!(
+                f,
+                "renormalization failed: discriminant = {} (must be >= -{:e})",
+                value, ROUNDING_TOLERANCE,
+            ),
+        }
+    }
+}
+
+impl std::error::Error for NormalizationError {}
+
 /// Renormalize momentum to strictly satisfy H = 0 (null geodesic condition).
 ///
-/// Solves for p_r from the quadratic A*p_r^2 + B*p_r + C = 0,
-/// choosing the root closest to the current p_r to maintain ray direction.
-pub fn renormalize_null<M: Metric>(state: &mut GeodesicState, metric: &M) {
+/// Solves for p_r from the quadratic `A*p_r^2 + B*p_r + C = 0`, choosing
+/// the root closest to the current p_r to preserve ray direction.
+///
+/// # Errors
+///
+/// Returns `NormalizationError::NegativeDiscriminant` when `B^2 - 4AC`
+/// falls below `-ROUNDING_TOLERANCE`. The geodesic has drifted off the
+/// null cone by more than rounding noise; the renormalizer cannot fix it
+/// and the caller should reset state from a known-good source or abort
+/// integration.
+pub fn renormalize_null<M: Metric>(
+    state: &mut GeodesicState,
+    metric: &M,
+) -> Result<(), NormalizationError> {
     let r = state.x[1];
     let theta = state.x[2];
     let g_inv = metric.contravariant(r, theta);
@@ -27,19 +73,34 @@ pub fn renormalize_null<M: Metric>(state: &mut GeodesicState, metric: &M) {
     let c_quad =
         g[0] * p_t * p_t + g[10] * p_th * p_th + g[15] * p_ph * p_ph + 2.0 * g[3] * p_t * p_ph;
 
-    if a_quad.abs() > 1e-12 {
-        let discriminant = b_quad * b_quad - 4.0 * a_quad * c_quad;
-        if discriminant >= 0.0 {
-            let sqrt_d = discriminant.sqrt();
-            let sol1 = (-b_quad + sqrt_d) / (2.0 * a_quad);
-            let sol2 = (-b_quad - sqrt_d) / (2.0 * a_quad);
-
-            // Choose root closest to current p_r
-            state.p[1] = if (sol1 - p_r).abs() < (sol2 - p_r).abs() {
-                sol1
-            } else {
-                sol2
-            };
-        }
+    if a_quad.abs() <= 1e-12 {
+        // Degenerate: g^rr ≈ 0 (e.g., on horizon in some coordinate systems).
+        // Skip without error; the integrator will move past the singularity.
+        return Ok(());
     }
+
+    let discriminant = b_quad * b_quad - 4.0 * a_quad * c_quad;
+
+    if discriminant < -ROUNDING_TOLERANCE {
+        return Err(NormalizationError::NegativeDiscriminant {
+            value: discriminant,
+        });
+    }
+
+    // Clamp to 0 if in the rounding band: the geodesic is on the null cone
+    // within numerical precision; the negative value is rounding noise, not
+    // physical drift.
+    let safe_discriminant = discriminant.max(0.0);
+    let sqrt_d = safe_discriminant.sqrt();
+    let sol1 = (-b_quad + sqrt_d) / (2.0 * a_quad);
+    let sol2 = (-b_quad - sqrt_d) / (2.0 * a_quad);
+
+    // Choose root closest to current p_r to preserve ray direction.
+    state.p[1] = if (sol1 - p_r).abs() < (sol2 - p_r).abs() {
+        sol1
+    } else {
+        sol2
+    };
+
+    Ok(())
 }

--- a/physics-engine/gravitas-core/tests/normalize.rs
+++ b/physics-engine/gravitas-core/tests/normalize.rs
@@ -1,0 +1,87 @@
+//! Tests for the `renormalize_null` discriminant guard.
+//!
+//! Covers the three bands: valid input passes through; rounding-noise
+//! negative discriminant clamps to zero; severe negative discriminant
+//! returns `NormalizationError`.
+
+use gravitas::geodesic::GeodesicState;
+use gravitas::invariants::{
+    hamiltonian, renormalize_null, NormalizationError, ROUNDING_TOLERANCE,
+};
+use gravitas::metric::Kerr;
+
+/// Build a near-null state at radius r with given (E, L_z) and zero θ-momentum.
+/// Solves for p_r given the null constraint H = 0; returns the renormalized state.
+fn build_null_state(metric: &Kerr, r: f64, e: f64, l_z: f64) -> GeodesicState {
+    let mut state = GeodesicState {
+        x: [0.0, r, std::f64::consts::FRAC_PI_2, 0.0],
+        p: [-e, 0.0, 0.0, l_z], // p_t = -E for stationary observers
+    };
+    // Solve for p_r via the renormalize_null function itself.
+    // For test stability, we accept whatever it produces.
+    renormalize_null(&mut state, metric).expect("initial state should normalize");
+    state
+}
+
+#[test]
+fn renormalize_succeeds_on_valid_null_state() {
+    let metric = Kerr::new(1.0, 0.5);
+    let mut state = build_null_state(&metric, 10.0, 1.0, 3.0);
+    let result = renormalize_null(&mut state, &metric);
+    assert!(
+        result.is_ok(),
+        "valid null state should renormalize cleanly: {result:?}",
+    );
+}
+
+#[test]
+fn renormalize_clamps_small_negative_discriminant() {
+    // Build a state slightly off the null cone; rounding produces a tiny
+    // negative discriminant that should clamp without erroring.
+    let metric = Kerr::new(1.0, 0.5);
+    let mut state = build_null_state(&metric, 10.0, 1.0, 3.0);
+    // Perturb p_r by an amount within numerical noise.
+    state.p[1] += 1e-15;
+    let result = renormalize_null(&mut state, &metric);
+    assert!(
+        result.is_ok(),
+        "small perturbation should clamp, not error: {result:?}",
+    );
+    // After renormalization, H must be ≈ 0.
+    let h = hamiltonian(&state, &metric);
+    assert!(h.abs() < 1e-6, "post-renormalization H = {h} (must be < 1e-6)");
+}
+
+#[test]
+fn renormalize_errors_on_severe_negative_discriminant() {
+    // Construct a state strongly off the null cone (timelike with large p_t).
+    // The discriminant will be very negative; the function should error.
+    let metric = Kerr::new(1.0, 0.5);
+    // Set p_t = 0 (no energy) with large transverse θ-momentum:
+    //   A = g^rr (positive far from horizon)
+    //   B = 0 (since p_t = p_phi = 0 contribute to the cross terms)
+    //   C = g^θθ * p_θ² (positive)
+    //   discriminant = 0 - 4·A·C < 0
+    // No real p_r exists making H = 0 — the state is not renormalizable.
+    let mut state = GeodesicState {
+        x: [0.0, 10.0, std::f64::consts::FRAC_PI_2, 0.0],
+        p: [0.0, 0.0, 10.0, 0.0],
+    };
+    let result = renormalize_null(&mut state, &metric);
+    match result {
+        Err(NormalizationError::NegativeDiscriminant { value }) => {
+            assert!(
+                value < -ROUNDING_TOLERANCE,
+                "discriminant {value} should be below rounding band {ROUNDING_TOLERANCE:e}",
+            );
+        }
+        Ok(()) => panic!("expected NegativeDiscriminant error; got Ok"),
+    }
+}
+
+#[test]
+fn rounding_tolerance_is_strictly_positive() {
+    // Sanity: the band is positive (we negate it for the comparison).
+    assert!(ROUNDING_TOLERANCE > 0.0);
+    assert!(ROUNDING_TOLERANCE < 1e-6);
+}

--- a/physics-engine/gravitas-wasm/src/lib.rs
+++ b/physics-engine/gravitas-wasm/src/lib.rs
@@ -32,12 +32,28 @@ pub fn init_hooks() {
     console_error_panic_hook::set_once();
 }
 
-// SAB byte offsets (v2 Protocol)
+// SAB f32-index offsets. Each `sab_ptr.add(N)` advances by N f32 units
+// (= N * 4 bytes). Block ownership: CONTROL and CAMERA are written by
+// the main thread (operator inputs, camera pose); PHYSICS, TELEMETRY,
+// and LUTS are written by this worker. Single-writer per block.
 pub const OFFSET_CONTROL: usize = 0;
 pub const OFFSET_CAMERA: usize = 64;
 pub const OFFSET_PHYSICS: usize = 128;
 pub const OFFSET_TELEMETRY: usize = 256;
 pub const OFFSET_LUTS: usize = 2048;
+
+// Shadow curve cap. PHYSICS spans f32 indices 128..256 (128 slots);
+// offsets 0..15 hold reserved scalars (horizon, ISCO, mass, spin,
+// min_a, max_a, point count). The remaining 112 slots fit 56 (x, y)
+// points before the writer would overflow into TELEMETRY.
+pub const SHADOW_CURVE_OFFSET_IN_PHYSICS: usize = 16;
+pub const SHADOW_CURVE_MAX_POINTS: usize = 56;
+pub const SHADOW_CURVE_FLOATS: usize = SHADOW_CURVE_MAX_POINTS * 2;
+const _SHADOW_CURVE_FITS: () = assert!(
+    SHADOW_CURVE_OFFSET_IN_PHYSICS + SHADOW_CURVE_FLOATS
+        <= OFFSET_TELEMETRY - OFFSET_PHYSICS,
+    "SHADOW_CURVE_FLOATS overflows PHYSICS block; reduce SHADOW_CURVE_MAX_POINTS",
+);
 
 #[wasm_bindgen]
 pub struct PhysicsEngine {
@@ -71,8 +87,30 @@ impl PhysicsEngine {
         }
     }
 
-    pub fn attach_sab(&mut self, ptr: *mut f32) {
+    /// Attach an external SharedArrayBuffer pointer.
+    ///
+    /// # Safety
+    ///
+    /// Caller must guarantee:
+    /// 1. `ptr` is non-null and 4-byte aligned (f32 alignment).
+    /// 2. `ptr` remains valid for the lifetime of this engine.
+    /// 3. The JS side never writes to the PHYSICS, TELEMETRY, or LUTS
+    ///    blocks while this engine is running.
+    ///
+    /// (1) is checked at runtime and produces an `Err`. (2) and (3) are
+    /// caller responsibility and cannot be checked here.
+    pub fn attach_sab(&mut self, ptr: *mut f32) -> Result<(), JsValue> {
+        if ptr.is_null() {
+            return Err(JsValue::from_str("attach_sab: null pointer"));
+        }
+        let addr = ptr as usize;
+        if !addr.is_multiple_of(4) {
+            return Err(JsValue::from_str(
+                "attach_sab: misaligned pointer (f32 requires 4-byte alignment)",
+            ));
+        }
         self.external_sab_ptr = Some(ptr);
+        Ok(())
     }
 
     pub fn update_params(&mut self, mass: f64, spin: f64) {
@@ -312,6 +350,15 @@ impl PhysicsEngine {
             self.sab_buffer.as_mut_ptr()
         };
 
+        // SAFETY: sab_ptr is non-null, 4-byte aligned, and stays valid
+        // for the duration of this tick. Either it came from `attach_sab`
+        // (validated at attach time) or it points into our own
+        // `sab_buffer: Vec<f32>` (always non-null and aligned by Rust
+        // ownership). The PHYSICS, TELEMETRY, and LUTS blocks have a
+        // single writer (this worker); the JS bridge guarantees that
+        // contract. Offset arithmetic stays in-bounds by construction:
+        // OFFSET_* constants plus SHADOW_CURVE_MAX_POINTS bound the
+        // address range below the SAB allocation size.
         unsafe {
             // 1. READ INPUTS
             let mouse_dx = *sab_ptr.add(OFFSET_CONTROL + 1) as f64;
@@ -323,6 +370,11 @@ impl PhysicsEngine {
                 *sab_ptr.add(OFFSET_CONTROL + 4) as f64
             };
 
+            // Consume-on-read: main writes mouse/zoom deltas into
+            // CONTROL[1..3]; we zero them after reading. There is a small
+            // race window if main writes between our read and clear, but
+            // at 60-75 Hz pointer events the worst case is one frame of
+            // dropped input.
             *sab_ptr.add(OFFSET_CONTROL + 1) = 0.0;
             *sab_ptr.add(OFFSET_CONTROL + 2) = 0.0;
             *sab_ptr.add(OFFSET_CONTROL + 3) = 0.0;
@@ -370,18 +422,26 @@ impl PhysicsEngine {
                 let curve =
                     gravitas::physics::shadow::bardeen_shadow(&self.metric_bl, theta_obs, 32);
 
-                // CRITICAL: Clear the buffer first to avoid 'ghost' segments from previous frames
-                for i in 0..128 {
-                    *sab_ptr.add(OFFSET_PHYSICS + 16 + i) = 0.0;
+                // Clear the curve region so old frames don't leave ghost
+                // segments. The bound stays inside PHYSICS.
+                for i in 0..SHADOW_CURVE_FLOATS {
+                    *sab_ptr.add(OFFSET_PHYSICS + SHADOW_CURVE_OFFSET_IN_PHYSICS + i) = 0.0;
                 }
 
-                // Write all points (up to 64 total)
-                let actual_points = curve.len().min(64);
-                *sab_ptr.add(OFFSET_PHYSICS + 15) = actual_points as f32; // Store point count
+                // Write up to SHADOW_CURVE_MAX_POINTS points; truncate the rest.
+                let actual_points = curve.len().min(SHADOW_CURVE_MAX_POINTS);
+                *sab_ptr.add(OFFSET_PHYSICS + 15) = actual_points as f32;
 
                 for i in 0..actual_points {
-                    *sab_ptr.add(OFFSET_PHYSICS + 16 + i * 2) = curve[i].0 as f32;
-                    *sab_ptr.add(OFFSET_PHYSICS + 16 + i * 2 + 1) = curve[i].1 as f32;
+                    let slot = OFFSET_PHYSICS + SHADOW_CURVE_OFFSET_IN_PHYSICS + i * 2;
+                    debug_assert!(
+                        slot + 1 < OFFSET_TELEMETRY,
+                        "shadow curve write at slot {} would overflow into TELEMETRY ({})",
+                        slot,
+                        OFFSET_TELEMETRY,
+                    );
+                    *sab_ptr.add(slot) = curve[i].0 as f32;
+                    *sab_ptr.add(slot + 1) = curve[i].1 as f32;
                 }
 
                 // Extents for fast bounding box checks

--- a/physics-engine/gravitas-wasm/tests/sab_bounds.rs
+++ b/physics-engine/gravitas-wasm/tests/sab_bounds.rs
@@ -1,0 +1,56 @@
+//! Bounds-check tests for SAB writes.
+//!
+//! These pin the layout constants so a future change that would let the
+//! shadow-curve writer overflow PHYSICS into TELEMETRY fails at test time.
+
+use gravitas_wasm::{
+    OFFSET_CAMERA, OFFSET_CONTROL, OFFSET_LUTS, OFFSET_PHYSICS, OFFSET_TELEMETRY,
+    SHADOW_CURVE_FLOATS, SHADOW_CURVE_MAX_POINTS, SHADOW_CURVE_OFFSET_IN_PHYSICS,
+};
+
+#[test]
+fn block_offsets_are_monotonic_and_aligned() {
+    assert!(OFFSET_CONTROL < OFFSET_CAMERA);
+    assert!(OFFSET_CAMERA < OFFSET_PHYSICS);
+    assert!(OFFSET_PHYSICS < OFFSET_TELEMETRY);
+    assert!(OFFSET_TELEMETRY < OFFSET_LUTS);
+    // Each offset is a valid f32 index (no fractional alignment).
+    assert_eq!(OFFSET_CONTROL % 1, 0);
+    assert_eq!(OFFSET_CAMERA % 1, 0);
+    assert_eq!(OFFSET_PHYSICS % 1, 0);
+}
+
+#[test]
+fn shadow_curve_max_points_fits_physics_block() {
+    let physics_block_floats = OFFSET_TELEMETRY - OFFSET_PHYSICS;
+    let last_slot_in_curve =
+        SHADOW_CURVE_OFFSET_IN_PHYSICS + (SHADOW_CURVE_FLOATS - 1);
+    assert!(
+        last_slot_in_curve < physics_block_floats,
+        "Last shadow-curve slot {} >= PHYSICS block size {}; would overflow into TELEMETRY",
+        last_slot_in_curve,
+        physics_block_floats,
+    );
+}
+
+#[test]
+fn shadow_curve_floats_equals_max_points_times_two() {
+    assert_eq!(SHADOW_CURVE_FLOATS, SHADOW_CURVE_MAX_POINTS * 2);
+}
+
+#[test]
+fn shadow_curve_max_writer_slot_is_below_telemetry() {
+    // The writer pattern is `OFFSET_PHYSICS + 16 + i*2 + 1` for i in 0..actual_points.
+    // With actual_points capped at SHADOW_CURVE_MAX_POINTS, the maximum absolute
+    // slot is OFFSET_PHYSICS + 16 + (MAX-1)*2 + 1.
+    let max_slot = OFFSET_PHYSICS
+        + SHADOW_CURVE_OFFSET_IN_PHYSICS
+        + (SHADOW_CURVE_MAX_POINTS - 1) * 2
+        + 1;
+    assert!(
+        max_slot < OFFSET_TELEMETRY,
+        "Max writer slot {} >= OFFSET_TELEMETRY {}",
+        max_slot,
+        OFFSET_TELEMETRY,
+    );
+}

--- a/src/workers/physics.worker.ts
+++ b/src/workers/physics.worker.ts
@@ -59,7 +59,11 @@ self.onmessage = async (e: MessageEvent) => {
     try {
       const wasmModuleWrap = await import("blackhole-physics");
       const wasmModule = await wasmModuleWrap.default();
-      const { PhysicsEngine } = wasmModuleWrap;
+      const { PhysicsEngine, init_hooks } = wasmModuleWrap;
+
+      // Wire the Rust panic hook so panics surface as stack traces in
+      // the JS console instead of silent worker termination.
+      init_hooks();
 
       engine = new PhysicsEngine(mass, spin);
 


### PR DESCRIPTION
Three small fixes to the physics engine and the worker bridge.

**SAB shadow-curve overflow.** The shadow-curve writer in `gravitas-wasm` could write 64 (x, y) points plus a 128-slot clear loop into the PHYSICS block, which only holds 128 f32 slots and reserves 16 for scalars. The 64-point write overflowed by 15 slots into TELEMETRY, corrupting the FPS counter and frame-index reads on the main thread. Capped at 56 points with a const-time assert and a debug_assert per write.

**FFI safety contract.** `attach_sab` accepted any pointer JS handed it. Added null + 4-byte alignment checks (returns `Result`) and documented the SAFETY contract on the unsafe block in `tick_sab` so the invariants the caller must uphold are visible at the callsite.

**Worker panic hook.** `init_hooks` was exported from `gravitas-wasm` but never invoked, so any Rust panic in the worker was swallowed as a generic "worker terminated" message. Now called immediately after the WASM module loads.

**Renormalize discriminant.** `renormalize_null` solved a quadratic in p_r and silently no-op'd when the discriminant went slightly negative (rounding noise after long integration runs), leaving the caller with stale state on the wrong side of the null cone. Replaced with a three-band guard: nonneg passes through; values in `[-1e-12, 0)` clamp to zero; anything more negative returns `NormalizationError`. The integrator maps the error to a new `NormalizationFailure` termination reason.

## Test plan

- `cargo test --manifest-path physics-engine/Cargo.toml` — clean
- `bun run test` — 326/326 pass
- `bun run build:wasm` — clean
- New: `physics-engine/gravitas-wasm/tests/sab_bounds.rs` (4 cases, layout invariants)
- New: `physics-engine/gravitas-core/tests/normalize.rs` (4 cases, three-band coverage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Physics engine now properly detects and terminates invalid calculations that drift off the null cone, rather than silently continuing with corrupted state.

* **Improvements**
  * Enhanced validation and error reporting for physics engine initialization.
  * Shadow curve rendering now includes proper boundary checks and point capping for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->