### PR TITLE
refactor(sab): canonical schema + page-visibility worker throttle

### DIFF
--- a/src/engine/physics-bridge.ts
+++ b/src/engine/physics-bridge.ts
@@ -120,6 +120,28 @@ export class PhysicsBridge {
     return !!(this.engine || this.workerReady);
   }
 
+  /**
+   * Wire `document.visibilitychange` so the worker drops to its idle
+   * loop when the tab is hidden and resumes 75 Hz on focus. Without
+   * this, the worker keeps full pace in background tabs and burns
+   * battery on mobile.
+   *
+   * Returns a teardown function the caller invokes on unmount.
+   */
+  public attachVisibilityListener(): () => void {
+    if (typeof document === "undefined") return () => {};
+    const handler = () => {
+      if (!this.worker) return;
+      this.worker.postMessage({
+        type: "VISIBILITY",
+        data: { hidden: document.visibilityState === "hidden" },
+      });
+    };
+    document.addEventListener("visibilitychange", handler);
+    handler(); // sync initial state
+    return () => document.removeEventListener("visibilitychange", handler);
+  }
+
   public async ensureInitialized(): Promise<void> {
     if (!this.initializationPromise) {
       return this.initialize();

--- a/src/engine/physics-bridge.ts
+++ b/src/engine/physics-bridge.ts
@@ -1,14 +1,5 @@
-// Memory Protocol v2 Offsets (Must match Rust lib.rs)
-// These are F32 ELEMENT indices, NOT byte offsets.
-// To get byte offset: multiply by 4.
-// To get Int32Array index: same as f32 index (both are 4-byte elements).
-export const OFFSETS = {
-  CONTROL: 0,
-  CAMERA: 64,
-  PHYSICS: 128,
-  TELEMETRY: 256,
-  LUTS: 2048,
-} as const;
+export { OFFSETS, BLOCK_FLOATS, TELEMETRY_SLOTS } from "./sab-schema";
+import { OFFSETS } from "./sab-schema";
 
 export class PhysicsBridge {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/engine/sab-schema.ts
+++ b/src/engine/sab-schema.ts
@@ -1,0 +1,54 @@
+/**
+ * Canonical SharedArrayBuffer layout for the physics ↔ renderer protocol.
+ *
+ * This file is the single source of truth. The Rust side (`gravitas-wasm`)
+ * pins the same values in `OFFSET_*` constants and a comment requiring
+ * them to match this file.
+ *
+ * Block ownership:
+ *   CONTROL   : main-thread writes (operator inputs).
+ *   CAMERA    : main-thread writes (camera pose).
+ *   PHYSICS   : worker writes (integration state, shadow curve).
+ *   TELEMETRY : worker writes (sequence counter, FPS, frame index, dt).
+ *   LUTS      : worker writes (precomputed lookup tables).
+ *
+ * Offsets are f32 element indices, not byte offsets. Multiply by 4 for
+ * byte offsets; Int32Array uses the same indices since both are 4-byte
+ * elements.
+ */
+
+/** Branded type to distinguish a byte offset from an f32 index. */
+export type SabByteOffset = number & { readonly __brand: "SabByteOffset" };
+
+/** Branded type for an f32 element index into the SAB. */
+export type SabFloatIndex = number & { readonly __brand: "SabFloatIndex" };
+
+const findex = (n: number): SabFloatIndex => n as SabFloatIndex;
+
+/** F32 element offsets for each block. */
+export const OFFSETS = {
+  CONTROL: findex(0),
+  CAMERA: findex(64),
+  PHYSICS: findex(128),
+  TELEMETRY: findex(256),
+  LUTS: findex(2048),
+} as const;
+
+/** Block sizes in f32 element count. */
+export const BLOCK_FLOATS = {
+  CONTROL: OFFSETS.CAMERA - OFFSETS.CONTROL,
+  CAMERA: OFFSETS.PHYSICS - OFFSETS.CAMERA,
+  PHYSICS: OFFSETS.TELEMETRY - OFFSETS.PHYSICS,
+  TELEMETRY: OFFSETS.LUTS - OFFSETS.TELEMETRY,
+} as const;
+
+/** Slot offsets inside the TELEMETRY block (relative). */
+export const TELEMETRY_SLOTS = {
+  SEQUENCE: 0,
+  FPS: 1,
+  FRAME_INDEX: 2,
+  DT: 3,
+} as const;
+
+/** Shadow-curve cap inside PHYSICS (16 reserved scalars + 56 (x,y) points). */
+export const SHADOW_CURVE_MAX_POINTS = 56;

--- a/src/workers/physics.worker.ts
+++ b/src/workers/physics.worker.ts
@@ -25,9 +25,15 @@ let sabSequenceView: Int32Array; // Used for Atomic synchronization
 const IDLE_THRESHOLD_MS = 3000;
 let isIdle = false;
 let idleStartTime = 0;
+let tabHidden = false; // set by VISIBILITY messages from the main thread
 
 self.onmessage = async (e: MessageEvent) => {
   const { type, data } = e.data;
+
+  if (type === "VISIBILITY") {
+    tabHidden = !!(data as { hidden: boolean }).hidden;
+    return;
+  }
 
   if (type === "INIT") {
     const { sab: sharedBuffer, mass, spin } = data as WorkerInitialData;
@@ -164,8 +170,9 @@ function calculate() {
 
   // High-Precision Loop Control
   // Active: 75 Hz (adequate for 60 FPS rendering with margin, ~37% less CPU than 120 Hz)
-  // Idle: 1 Hz (physics barely changes without input)
-  const targetHz = isIdle ? 1 : 75;
+  // Idle: 1 Hz when input is quiet for IDLE_THRESHOLD_MS or when the tab
+  //       is hidden (Page Visibility API signal from main thread).
+  const targetHz = isIdle || tabHidden ? 1 : 75;
   const targetDelay = 1000 / targetHz;
   const processingTime = performance.now() - currentTime;
   const finalDelay = Math.max(0, targetDelay - processingTime);

--- a/src/workers/physics.worker.ts
+++ b/src/workers/physics.worker.ts
@@ -14,13 +14,7 @@ let engine: import("blackhole-physics").PhysicsEngine | null = null;
 let sab: SharedArrayBuffer | null = null;
 let lastTickTime = 0;
 
-// Constants matching lib.rs
-const OFFSETS = {
-  CONTROL: 0,
-  CAMERA: 64,
-  PHYSICS: 128,
-  TELEMETRY: 256,
-} as const;
+import { OFFSETS } from "@/engine/sab-schema";
 
 // Subarray views for the SharedArrayBuffer
 let sabControlView: Float32Array;


### PR DESCRIPTION
Two small, independent improvements to the physics-engine bridge.

**Canonical SAB schema.** `OFFSETS` was duplicated across `src/engine/physics-bridge.ts` and `src/workers/physics.worker.ts`, and the worker's copy was missing the `LUTS` block. A single edit on either side could silently desync the contract. Moved the layout into a new `src/engine/sab-schema.ts` (branded `SabByteOffset` / `SabFloatIndex` types, `OFFSETS`, `BLOCK_FLOATS`, `TELEMETRY_SLOTS`, `SHADOW_CURVE_MAX_POINTS`). The bridge re-exports for backward compat; the worker imports from the schema. The Rust side already pins the same values with a comment requiring them to match.

**Page Visibility API throttle.** The worker's idle detection only watched mouse and zoom input, so switching tabs mid-interaction left the worker running at 75 Hz in the background — wasted CPU and battery for no rendered output. `PhysicsBridge.attachVisibilityListener()` now subscribes to `document.visibilitychange` and posts a `VISIBILITY` message to the worker. The worker stores the flag and ORs it into the existing idle decision: idle OR hidden -> 1 Hz, otherwise 75 Hz.

## Test plan

- `bun run type-check` — clean
- `bun run test` — 326/326 pass
- Verify in browser: with the tab focused, FPS counter shows ~75; switching tabs and watching `chrome://inspect` should show worker dropping to 1 Hz; refocusing returns it to 75.