### PR TITLE
fix(ui): logo not loading in HUD and ControlPanel

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -54,6 +54,15 @@ const nextConfig = {
             key: "Cross-Origin-Embedder-Policy",
             value: "require-corp",
           },
+          // COEP=require-corp rejects same-origin sub-resources that don't
+          // declare an embedding policy. Static assets in /public (logo,
+          // favicon, the static-fallback render) and Next.js's optimized
+          // image responses both go through this header rule, so a single
+          // CORP=same-origin declaration unblocks every same-origin embed.
+          {
+            key: "Cross-Origin-Resource-Policy",
+            value: "same-origin",
+          },
         ],
       },
     ];

--- a/src/components/ui/ControlPanel.tsx
+++ b/src/components/ui/ControlPanel.tsx
@@ -430,8 +430,8 @@ export const ControlPanel = ({
                   <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mb-8">
                     <div className="flex items-center gap-4 w-full sm:w-auto">
                       <Image
-                        src="/icon.png"
-                        alt="Project Icon"
+                        src="/brand-logo.png"
+                        alt="Interactive Black Hole Simulation Physics Engine"
                         width={48}
                         height={48}
                         className="w-12 h-12 object-contain icon-glow shrink-0"


### PR DESCRIPTION
Two unrelated bugs surface as the same broken-image symptom in the operator
surface. ControlPanel referenced /icon.png; that asset was never committed
to public/. Switched the src to /brand-logo.png so both the HUD and the
ControlPanel header render the same mark.

next.config.mjs declared COOP=same-origin and COEP=require-corp but no
Cross-Origin-Resource-Policy. Under require-corp every embedded sub-resource
must explicitly declare an embedding policy or the browser refuses to render
it. Same-origin static files in /public and Next.js's optimized image
responses both flow through the headers() rule, so a single CORP=same-origin
declaration unblocks every same-origin embed without weakening the
cross-origin isolation that SAB depends on.

## Test plan

- [x] Dev server: GET /brand-logo.png returns HTTP 200 with Content-Type: image/png plus the three Cross-Origin-* headers
- [x] HUD logo renders
- [x] ControlPanel header logo renders
- [x] bun run type-check clean
- [x] bun run test green (lefthook pre-push gate passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the control panel header logo with a new branding asset. Alternative text descriptions have been refined for improved clarity and accessibility.

* **Chores**
  * Added cross-origin resource policy header configuration to the application's global settings, complementing existing cross-origin security protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->