### PR TITLE
test(sp3): Bardeen 1973 numerical regression + SAB/mode/motion contract tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write \"**/*.{js,ts,tsx,css,md,json}\"",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "physics:regress": "vitest run --testNamePattern='physics-regression'",
+    "physics:regress": "cd physics-engine && cargo test --release -p gravitas-core --test conservation --test photon_ring --test isco --test schwarzschild_degenerate --test near_extremal --test normalize",
     "seo:check": "bun scripts/seo-provenance.ts src/app/layout.tsx",
     "seo:ping": "bun scripts/indexnow-ping.ts",
     "shader:check": "vitest run --testNamePattern='shader-visual'",

--- a/physics-engine/gravitas-core/Cargo.toml
+++ b/physics-engine/gravitas-core/Cargo.toml
@@ -24,3 +24,4 @@ serde = ["dep:serde"]
 
 [dev-dependencies]
 approx = "0.5"
+proptest = "1"

--- a/physics-engine/gravitas-core/tests/common/mod.rs
+++ b/physics-engine/gravitas-core/tests/common/mod.rs
@@ -1,0 +1,82 @@
+//! Shared regression-test fixtures.
+//!
+//! Bardeen, J. M. (1973), "Timelike and null geodesics in the Kerr metric",
+//! in *Black Holes* (eds. DeWitt & DeWitt), is the canonical reference for
+//! analytic Kerr orbits. The closed-form expressions for the photon-sphere
+//! critical impact parameter (Eq. 28 in the cited prograde-equatorial form)
+//! and the ISCO (Eq. 38, sometimes credited Bardeen-Press-Teukolsky 1972)
+//! are reproduced here as the regression source of truth, cross-checked
+//! against MTW *Gravitation* Table 33.1 and the EHT Sgr A* / M87* spin
+//! papers (which use the same formulas to bracket inferred spin).
+//!
+//! Drift threshold for E, L_z, Carter Q over 10^5 steps: 1e-9 absolute,
+//! per the project's physics regression rule.
+
+#![allow(dead_code)] // each integration test compiles its own copy
+
+/// Solar-mass black hole in geometric units throughout (M = 1).
+pub const MASS_M: f64 = 1.0;
+
+/// Drift threshold for conservation invariants over `STEP_COUNT` steps.
+pub const DRIFT_THRESHOLD: f64 = 1e-9;
+
+/// Step budget for conservation runs. 10^5 matches the rule and keeps
+/// release-mode wall time under a few seconds on a modern laptop.
+pub const STEP_COUNT: usize = 100_000;
+
+/// Tolerance for closed-form analytic predictions vs the engine's outputs.
+pub const ANALYTIC_TOLERANCE: f64 = 1e-6;
+
+/// Photon-sphere critical impact parameter for a prograde equatorial null
+/// circular orbit (Bardeen 1973, Eq. 28, prograde branch):
+///
+///   b_c = -a + 6M cos( arccos(-a/M) / 3 )
+///
+/// Returns the analytic prediction for spin `a_star = a/M` with `M = 1`.
+pub fn bardeen_b_c_prograde(a_star: f64) -> f64 {
+    let a = a_star * MASS_M;
+    -a + 6.0 * MASS_M * ((-a / MASS_M).acos() / 3.0).cos()
+}
+
+/// Retrograde equatorial photon-sphere critical impact parameter (Bardeen
+/// 1973, Eq. 28, retrograde branch):
+///
+///   b_c = +a + 6M cos( arccos(+a/M) / 3 )
+pub fn bardeen_b_c_retrograde(a_star: f64) -> f64 {
+    let a = a_star * MASS_M;
+    a + 6.0 * MASS_M * ((a / MASS_M).acos() / 3.0).cos()
+}
+
+/// Bardeen-Press-Teukolsky ISCO radius for prograde equatorial circular
+/// orbits (Bardeen 1973 Eq. 38, prograde branch):
+///
+///   z_1 = 1 + (1 - a*^2)^(1/3) [ (1+a*)^(1/3) + (1-a*)^(1/3) ]
+///   z_2 = sqrt( 3 a*^2 + z_1^2 )
+///   r_isco = M ( 3 + z_2 - sqrt( (3 - z_1)(3 + z_1 + 2 z_2) ) )
+pub fn bardeen_r_isco_prograde(a_star: f64) -> f64 {
+    let a2 = a_star * a_star;
+    let z1 =
+        1.0 + (1.0 - a2).cbrt() * ((1.0 + a_star).cbrt() + (1.0 - a_star).cbrt());
+    let z2 = (3.0 * a2 + z1 * z1).sqrt();
+    MASS_M * (3.0 + z2 - ((3.0 - z1) * (3.0 + z1 + 2.0 * z2)).sqrt())
+}
+
+/// Retrograde branch of the Bardeen-Press-Teukolsky ISCO formula.
+pub fn bardeen_r_isco_retrograde(a_star: f64) -> f64 {
+    let a2 = a_star * a_star;
+    let z1 =
+        1.0 + (1.0 - a2).cbrt() * ((1.0 + a_star).cbrt() + (1.0 - a_star).cbrt());
+    let z2 = (3.0 * a2 + z1 * z1).sqrt();
+    MASS_M * (3.0 + z2 + ((3.0 - z1) * (3.0 + z1 + 2.0 * z2)).sqrt())
+}
+
+/// Outer event-horizon radius for Kerr: r_+ = M + sqrt(M^2 - a^2).
+pub fn kerr_event_horizon(a_star: f64) -> f64 {
+    let a = a_star * MASS_M;
+    MASS_M + (MASS_M * MASS_M - a * a).sqrt()
+}
+
+/// Spin grid used across regression suites. Covers Schwarzschild (0),
+/// moderate (0.5), high (0.9), near-extremal (0.99), and the EHT-cited
+/// upper-bracket (0.998).
+pub const REGRESSION_SPIN_GRID: [f64; 5] = [0.0, 0.5, 0.9, 0.99, 0.998];

--- a/physics-engine/gravitas-core/tests/conservation.rs
+++ b/physics-engine/gravitas-core/tests/conservation.rs
@@ -1,0 +1,88 @@
+//! Conservation invariants for null geodesics in Kerr spacetime.
+//!
+//! For an unperturbed null geodesic the energy E = -p_t, axial angular
+//! momentum L_z = p_phi, and Carter constant Q are all integrals of
+//! motion. This suite asserts that the engine's integrator preserves
+//! all three within `DRIFT_THRESHOLD` over `STEP_COUNT` integration steps.
+//!
+//! Reference geodesic: an equatorial null ray launched at r = 20M with a
+//! tangential momentum tuned so the orbit is bound but does not cross
+//! the horizon over the test budget. The same setup is run at three spin
+//! values across the regression spin grid (Schwarzschild, moderate Kerr,
+//! near-extremal) so that a regression in the metric, the Hamiltonian
+//! derivative, the integrator, or the renormalization step shows up as
+//! drift in at least one configuration.
+
+mod common;
+
+use common::{DRIFT_THRESHOLD, STEP_COUNT};
+use gravitas::geodesic::{
+    integrate, GeodesicState, IntegrationMethod, IntegrationOptions, TerminationReason,
+};
+use gravitas::invariants::compute_constants;
+use gravitas::metric::Kerr;
+
+/// Build an outward-launched null ray in the equatorial plane with the
+/// given axial angular momentum. The integrator's renormalization step
+/// pins p_r so the state is genuinely null (H = 0) after construction.
+fn equatorial_null_ray(r: f64, l_z: f64) -> GeodesicState {
+    GeodesicState {
+        x: [0.0, r, std::f64::consts::FRAC_PI_2, 0.0],
+        p: [-1.0, 0.0, 0.0, l_z],
+    }
+}
+
+fn run_long_integration(spin: f64, l_z: f64) -> (f64, f64, f64) {
+    let metric = Kerr::new(1.0, spin);
+    let initial = equatorial_null_ray(20.0, l_z);
+    let options = IntegrationOptions {
+        method: IntegrationMethod::AdaptiveRKF45,
+        tolerance: 1e-10,
+        initial_step: 0.01,
+        max_steps: STEP_COUNT,
+        escape_radius: 1.0e6,
+        renormalize_interval: 10,
+        record_path: false,
+    };
+
+    let traj = integrate(&initial, &metric, &options);
+    let initial_constants = compute_constants(&initial, &metric);
+    let final_constants = compute_constants(&traj.final_state, &metric);
+
+    if matches!(traj.termination, TerminationReason::NormalizationFailure) {
+        panic!("integrator hit NormalizationFailure at step {}", traj.steps_taken);
+    }
+
+    let drift_e = (final_constants.energy - initial_constants.energy).abs();
+    let drift_lz =
+        (final_constants.angular_momentum - initial_constants.angular_momentum).abs();
+    let drift_q =
+        (final_constants.carter_constant - initial_constants.carter_constant).abs();
+    (drift_e, drift_lz, drift_q)
+}
+
+#[test]
+fn schwarzschild_equatorial_conserves_invariants() {
+    let (de, dlz, dq) = run_long_integration(0.0, 4.0);
+    assert!(de < DRIFT_THRESHOLD, "Schwarzschild ΔE={de} exceeds {DRIFT_THRESHOLD}");
+    assert!(dlz < DRIFT_THRESHOLD, "Schwarzschild ΔL_z={dlz}");
+    assert!(dq < DRIFT_THRESHOLD, "Schwarzschild ΔQ={dq}");
+}
+
+#[test]
+fn moderate_kerr_equatorial_conserves_invariants() {
+    let (de, dlz, dq) = run_long_integration(0.5, 4.0);
+    assert!(de < DRIFT_THRESHOLD, "a*=0.5 ΔE={de} exceeds {DRIFT_THRESHOLD}");
+    assert!(dlz < DRIFT_THRESHOLD, "a*=0.5 ΔL_z={dlz}");
+    assert!(dq < DRIFT_THRESHOLD, "a*=0.5 ΔQ={dq}");
+}
+
+#[test]
+fn near_extremal_kerr_equatorial_conserves_invariants() {
+    // Near-extremal needs a slightly higher angular momentum to stay
+    // outside the rapidly-shrinking ergosphere over the long step budget.
+    let (de, dlz, dq) = run_long_integration(0.99, 5.0);
+    assert!(de < DRIFT_THRESHOLD, "a*=0.99 ΔE={de} exceeds {DRIFT_THRESHOLD}");
+    assert!(dlz < DRIFT_THRESHOLD, "a*=0.99 ΔL_z={dlz}");
+    assert!(dq < DRIFT_THRESHOLD, "a*=0.99 ΔQ={dq}");
+}

--- a/physics-engine/gravitas-core/tests/isco.rs
+++ b/physics-engine/gravitas-core/tests/isco.rs
@@ -1,0 +1,70 @@
+//! ISCO regression: the engine's `Kerr::isco(orbit)` must match the
+//! Bardeen-Press-Teukolsky formula (Bardeen 1973 Eq. 38) across the
+//! standard spin grid, both prograde and retrograde.
+//!
+//! Schwarzschild limit: r_isco -> 6M for both branches at a* = 0.
+//! Extremal prograde: r_isco -> M as a* -> 1.
+//! Extremal retrograde: r_isco -> 9M as a* -> 1.
+
+mod common;
+
+use common::{
+    bardeen_r_isco_prograde, bardeen_r_isco_retrograde, REGRESSION_SPIN_GRID,
+};
+use gravitas::metric::{Kerr, Orbit};
+
+const ISCO_TOLERANCE: f64 = 1e-6;
+
+#[test]
+fn isco_prograde_matches_bardeen_across_spin_grid() {
+    for &a_star in REGRESSION_SPIN_GRID.iter() {
+        let metric = Kerr::new(1.0, a_star);
+        let predicted = metric.isco(Orbit::Prograde);
+        let expected = bardeen_r_isco_prograde(a_star);
+        let err = (predicted - expected).abs();
+        assert!(
+            err < ISCO_TOLERANCE,
+            "a*={a_star} prograde: engine={predicted}, Bardeen={expected}, |Δ|={err}",
+        );
+    }
+}
+
+#[test]
+fn isco_retrograde_matches_bardeen_across_spin_grid() {
+    // Skip a* = 0 because the engine returns 6M as a fast path; both
+    // branches collapse there and the Bardeen formula numerically agrees.
+    for &a_star in REGRESSION_SPIN_GRID.iter().filter(|&&a| a > 0.0) {
+        let metric = Kerr::new(1.0, a_star);
+        let predicted = metric.isco(Orbit::Retrograde);
+        let expected = bardeen_r_isco_retrograde(a_star);
+        let err = (predicted - expected).abs();
+        assert!(
+            err < ISCO_TOLERANCE,
+            "a*={a_star} retrograde: engine={predicted}, Bardeen={expected}, |Δ|={err}",
+        );
+    }
+}
+
+#[test]
+fn isco_schwarzschild_limit_is_six_m_both_branches() {
+    let metric = Kerr::new(1.0, 0.0);
+    assert!((metric.isco(Orbit::Prograde) - 6.0).abs() < ISCO_TOLERANCE);
+    assert!((metric.isco(Orbit::Retrograde) - 6.0).abs() < ISCO_TOLERANCE);
+}
+
+#[test]
+fn isco_near_extremal_prograde_under_two_m() {
+    // Near-extremal prograde collapses toward r_+ = M; at a* = 0.998 the
+    // analytic value is around 1.24M.
+    let metric = Kerr::new(1.0, 0.998);
+    let r = metric.isco(Orbit::Prograde);
+    assert!(r > 1.0 && r < 2.0, "a*=0.998 prograde isco={r} outside (M, 2M)");
+}
+
+#[test]
+fn isco_near_extremal_retrograde_above_eight_m() {
+    // Near-extremal retrograde grows toward 9M; at a* = 0.998 it sits near 8.97M.
+    let metric = Kerr::new(1.0, 0.998);
+    let r = metric.isco(Orbit::Retrograde);
+    assert!(r > 8.5 && r < 9.0, "a*=0.998 retrograde isco={r} outside (8.5M, 9M)");
+}

--- a/physics-engine/gravitas-core/tests/near_extremal.rs
+++ b/physics-engine/gravitas-core/tests/near_extremal.rs
@@ -1,0 +1,67 @@
+//! Near-extremal Kerr stability: at a* = 0.99 the outer horizon collapses
+//! toward M and the integrator is most likely to step into the horizon
+//! or hit the renormalization band defined in `invariants::renormalization`.
+//! Property-based test asserts that for a wide spread of equatorial-ish
+//! initial conditions the integrator either escapes, terminates cleanly,
+//! or returns NormalizationFailure: never NaN, never panic, never silent
+//! divergence.
+
+mod common;
+
+use gravitas::geodesic::{
+    integrate, GeodesicState, IntegrationMethod, IntegrationOptions, TerminationReason,
+};
+use gravitas::metric::Kerr;
+use proptest::prelude::*;
+
+/// Deliberately tight step budget to keep the proptest run under a few
+/// seconds; the property under test is "no NaN within budget", not
+/// "all rays escape".
+const NEAR_EXTREMAL_STEP_BUDGET: usize = 2000;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 200,
+        max_shrink_iters: 64,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn near_extremal_no_nan_for_random_inputs(
+        r0 in 6.0_f64..30.0,
+        theta0 in 0.2_f64..(std::f64::consts::PI - 0.2),
+        p_r in -0.5_f64..0.5,
+        p_theta in -0.3_f64..0.3,
+        l_z in 1.0_f64..6.0,
+    ) {
+        let metric = Kerr::new(1.0, 0.99);
+        let initial = GeodesicState {
+            x: [0.0, r0, theta0, 0.0],
+            p: [-1.0, p_r, p_theta, l_z],
+        };
+
+        let options = IntegrationOptions {
+            method: IntegrationMethod::AdaptiveRKF45,
+            tolerance: 1e-9,
+            initial_step: 1e-3,
+            max_steps: NEAR_EXTREMAL_STEP_BUDGET,
+            escape_radius: 1.0e6,
+            renormalize_interval: 5,
+            record_path: false,
+        };
+
+        let traj = integrate(&initial, &metric, &options);
+
+        // Whatever termination reason fired, the final state must be finite.
+        let s = &traj.final_state;
+        prop_assert!(s.x.iter().all(|v| v.is_finite()), "x had non-finite: {:?}", s.x);
+        prop_assert!(s.p.iter().all(|v| v.is_finite()), "p had non-finite: {:?}", s.p);
+
+        // NormalizationFailure / Horizon / Escape / MaxSteps are all OK; the
+        // contract is just "terminated cleanly without garbage state".
+        prop_assert!(
+            traj.termination != TerminationReason::None,
+            "integrator returned None termination",
+        );
+    }
+}

--- a/physics-engine/gravitas-core/tests/photon_ring.rs
+++ b/physics-engine/gravitas-core/tests/photon_ring.rs
@@ -1,0 +1,55 @@
+//! Photon-sphere regression: the engine's photon-sphere radius must agree
+//! with the analytic Bardeen 1973 form across the spin grid, prograde
+//! branch only (the public API exposes a single prograde photon sphere).
+//!
+//! The Bardeen 1973 formula reproduced in `common::bardeen_b_c_prograde`
+//! returns the critical impact parameter at infinity, not the radius;
+//! the on-grid radius itself comes from the closed form
+//!
+//!   r_ph = 2M [ 1 + cos( (2/3) arccos(-a*) ) ]
+//!
+//! which is what `Kerr::photon_sphere` implements. This test pins that
+//! formula against an independent recomputation, so a future refactor
+//! can't silently invert the cosine branch.
+
+mod common;
+
+use common::REGRESSION_SPIN_GRID;
+use gravitas::metric::Kerr;
+
+const PHOTON_SPHERE_TOLERANCE: f64 = 1e-9;
+
+fn analytic_photon_sphere_prograde(a_star: f64) -> f64 {
+    2.0 * (1.0 + ((2.0 / 3.0) * (-a_star).acos()).cos())
+}
+
+#[test]
+fn photon_sphere_matches_bardeen_across_spin_grid() {
+    for &a_star in REGRESSION_SPIN_GRID.iter() {
+        let metric = Kerr::new(1.0, a_star);
+        let predicted = metric.photon_sphere();
+        let expected = analytic_photon_sphere_prograde(a_star);
+        let err = (predicted - expected).abs();
+        assert!(
+            err < PHOTON_SPHERE_TOLERANCE,
+            "a*={a_star}: r_ph engine={predicted}, Bardeen={expected}, |Δ|={err}",
+        );
+    }
+}
+
+#[test]
+fn photon_sphere_collapses_to_three_m_at_a_zero() {
+    // Schwarzschild: r_ph = 3M.
+    let metric = Kerr::new(1.0, 0.0);
+    let r_ph = metric.photon_sphere();
+    let err = (r_ph - 3.0).abs();
+    assert!(err < PHOTON_SPHERE_TOLERANCE, "Schwarzschild r_ph={r_ph}, expected 3M");
+}
+
+#[test]
+fn photon_sphere_approaches_m_at_extremal() {
+    // Extremal prograde: r_ph -> M as a* -> 1.
+    let metric = Kerr::new(1.0, 0.998);
+    let r_ph = metric.photon_sphere();
+    assert!(r_ph > 1.0 && r_ph < 1.5, "near-extremal r_ph={r_ph} outside (M, 1.5M)");
+}

--- a/physics-engine/gravitas-core/tests/schwarzschild_degenerate.rs
+++ b/physics-engine/gravitas-core/tests/schwarzschild_degenerate.rs
@@ -1,0 +1,94 @@
+//! Schwarzschild-degenerate path: at a* = 0 every Kerr-specific code
+//! branch collapses to the Schwarzschild form. Closed-form expectations:
+//!
+//!   r_+ = 2M (event horizon)
+//!   r_isco_prograde = 6M (Bardeen 1973 Eq. 38 collapses)
+//!   r_isco_retrograde = 6M (both branches coincide at a = 0)
+//!   r_ph = 3M (photon sphere)
+//!   omega_ZAMO = 0 (no frame dragging at a = 0)
+//!
+//! A regression that introduces a 1/a division anywhere in the metric
+//! tensor, frame-dragging code, or ISCO formula will fail at least one
+//! of these assertions.
+
+mod common;
+
+use common::ANALYTIC_TOLERANCE;
+use gravitas::metric::{Kerr, Metric, Orbit};
+
+const STRICT_TOLERANCE: f64 = 1e-12;
+
+#[test]
+fn event_horizon_is_two_m() {
+    let metric = Kerr::new(1.0, 0.0);
+    let r_plus = metric.event_horizon();
+    assert!(
+        (r_plus - 2.0).abs() < STRICT_TOLERANCE,
+        "r_+={r_plus}, expected 2M",
+    );
+}
+
+#[test]
+fn cauchy_horizon_collapses_to_zero() {
+    let metric = Kerr::new(1.0, 0.0);
+    let r_minus = metric.cauchy_horizon();
+    assert!(
+        r_minus.abs() < STRICT_TOLERANCE,
+        "Cauchy horizon at a=0 should be 0, got {r_minus}",
+    );
+}
+
+#[test]
+fn isco_prograde_is_six_m() {
+    let metric = Kerr::new(1.0, 0.0);
+    let r = metric.isco(Orbit::Prograde);
+    assert!(
+        (r - 6.0).abs() < ANALYTIC_TOLERANCE,
+        "Schwarzschild prograde isco={r}, expected 6M",
+    );
+}
+
+#[test]
+fn isco_retrograde_is_six_m() {
+    let metric = Kerr::new(1.0, 0.0);
+    let r = metric.isco(Orbit::Retrograde);
+    assert!(
+        (r - 6.0).abs() < ANALYTIC_TOLERANCE,
+        "Schwarzschild retrograde isco={r}, expected 6M",
+    );
+}
+
+#[test]
+fn photon_sphere_is_three_m() {
+    let metric = Kerr::new(1.0, 0.0);
+    let r = metric.photon_sphere();
+    assert!(
+        (r - 3.0).abs() < ANALYTIC_TOLERANCE,
+        "Schwarzschild photon sphere={r}, expected 3M",
+    );
+}
+
+#[test]
+fn frame_dragging_vanishes_everywhere_at_a_zero() {
+    let metric = Kerr::new(1.0, 0.0);
+    for &r in &[3.0, 5.0, 10.0, 50.0] {
+        let omega = metric.frame_dragging_equator(r);
+        assert!(
+            omega.abs() < STRICT_TOLERANCE,
+            "Schwarzschild frame dragging at r={r} should be 0, got {omega}",
+        );
+    }
+}
+
+#[test]
+fn ergosphere_collapses_to_horizon_at_a_zero() {
+    // r_ergo = M + sqrt(M^2 - a^2 cos^2 theta) -> 2M for a = 0 at any theta.
+    let metric = Kerr::new(1.0, 0.0);
+    for theta in [0.0, std::f64::consts::FRAC_PI_2, std::f64::consts::PI] {
+        let r_ergo = metric.ergosphere(theta);
+        assert!(
+            (r_ergo - 2.0).abs() < STRICT_TOLERANCE,
+            "Schwarzschild ergosphere at θ={theta} expected 2M, got {r_ergo}",
+        );
+    }
+}

--- a/src/__tests__/engine/sab-schema.test.ts
+++ b/src/__tests__/engine/sab-schema.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import {
+  OFFSETS,
+  BLOCK_FLOATS,
+  TELEMETRY_SLOTS,
+  SHADOW_CURVE_MAX_POINTS,
+} from "@/engine/sab-schema";
+
+describe("sab-schema offset arithmetic invariants", () => {
+  it("blocks are monotonically ordered", () => {
+    expect(OFFSETS.CONTROL).toBeLessThan(OFFSETS.CAMERA);
+    expect(OFFSETS.CAMERA).toBeLessThan(OFFSETS.PHYSICS);
+    expect(OFFSETS.PHYSICS).toBeLessThan(OFFSETS.TELEMETRY);
+    expect(OFFSETS.TELEMETRY).toBeLessThan(OFFSETS.LUTS);
+  });
+
+  it("all f32 offsets are non-negative integers", () => {
+    for (const v of Object.values(OFFSETS)) {
+      expect(Number.isInteger(v)).toBe(true);
+      expect(v).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("block floats sum equals LUTS offset", () => {
+    const sum =
+      BLOCK_FLOATS.CONTROL +
+      BLOCK_FLOATS.CAMERA +
+      BLOCK_FLOATS.PHYSICS +
+      BLOCK_FLOATS.TELEMETRY;
+    expect(sum).toBe(OFFSETS.LUTS);
+  });
+
+  it("TELEMETRY slots stay inside the TELEMETRY block", () => {
+    for (const slot of Object.values(TELEMETRY_SLOTS)) {
+      expect(slot).toBeGreaterThanOrEqual(0);
+      expect(slot).toBeLessThan(BLOCK_FLOATS.TELEMETRY);
+    }
+  });
+
+  it("shadow curve cap fits inside PHYSICS minus the 16-slot scalar header", () => {
+    const SCALAR_HEADER_FLOATS = 16;
+    const curveFloats = SHADOW_CURVE_MAX_POINTS * 2;
+    expect(SCALAR_HEADER_FLOATS + curveFloats).toBeLessThanOrEqual(
+      BLOCK_FLOATS.PHYSICS,
+    );
+  });
+
+  it("byte offsets round-trip through f32 indices", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom(...Object.values(OFFSETS)),
+        (floatIndex: number) => {
+          const byteOffset = floatIndex * 4;
+          expect(byteOffset % 4).toBe(0);
+          expect(byteOffset / 4).toBe(floatIndex);
+        },
+      ),
+    );
+  });
+});

--- a/src/__tests__/hooks/useReducedMotion.test.ts
+++ b/src/__tests__/hooks/useReducedMotion.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+interface MockMediaQueryList {
+  matches: boolean;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  dispatchChange: (matches: boolean) => void;
+}
+
+function installMatchMedia(initial: boolean): MockMediaQueryList {
+  let listener: ((e: MediaQueryListEvent) => void) | null = null;
+  const mql: MockMediaQueryList = {
+    matches: initial,
+    addEventListener: vi.fn((_event: string, handler: EventListener) => {
+      listener = handler as (e: MediaQueryListEvent) => void;
+    }),
+    removeEventListener: vi.fn(() => {
+      listener = null;
+    }),
+    dispatchChange(matches: boolean) {
+      this.matches = matches;
+      listener?.({ matches } as MediaQueryListEvent);
+    },
+  };
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => mql),
+  );
+  return mql;
+}
+
+describe("useReducedMotion", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns false when prefers-reduced-motion is not set", () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when prefers-reduced-motion is reduce on initial render", () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it("flips reactively when the media query change event fires", () => {
+    const mql = installMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mql.dispatchChange(true);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      mql.dispatchChange(false);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("removes its event listener on unmount", () => {
+    const mql = installMatchMedia(false);
+    const { unmount } = renderHook(() => useReducedMotion());
+    expect(mql.addEventListener).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(mql.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/hooks/useSimulationMode.test.ts
+++ b/src/__tests__/hooks/useSimulationMode.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSimulationMode } from "@/hooks/useSimulationMode";
+
+describe("useSimulationMode mutex state machine", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts in interactive mode", () => {
+    const { result } = renderHook(() => useSimulationMode());
+    expect(result.current.mode).toBe("interactive");
+    expect(result.current.cinematicVariant).toBeNull();
+    expect(result.current.isInteractive).toBe(true);
+  });
+
+  it("interactive -> transitioning -> cinematic on enterCinematic", () => {
+    const { result } = renderHook(() => useSimulationMode());
+
+    act(() => {
+      result.current.enterCinematic("orbit");
+    });
+    expect(result.current.mode).toBe("transitioning");
+    expect(result.current.cinematicVariant).toBe("orbit");
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.mode).toBe("cinematic");
+    expect(result.current.cinematicVariant).toBe("orbit");
+  });
+
+  it("ignores enterCinematic while transitioning", () => {
+    const { result } = renderHook(() => useSimulationMode());
+
+    act(() => {
+      result.current.enterCinematic("orbit");
+    });
+    const variantBefore = result.current.cinematicVariant;
+
+    act(() => {
+      result.current.enterCinematic("dive");
+    });
+    expect(result.current.mode).toBe("transitioning");
+    expect(result.current.cinematicVariant).toBe(variantBefore);
+  });
+
+  it("cinematic -> transitioning -> interactive on enterInteractive", () => {
+    const { result } = renderHook(() => useSimulationMode());
+
+    act(() => {
+      result.current.enterCinematic("dive");
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.mode).toBe("cinematic");
+
+    act(() => {
+      result.current.enterInteractive();
+    });
+    expect(result.current.mode).toBe("transitioning");
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.mode).toBe("interactive");
+    expect(result.current.cinematicVariant).toBeNull();
+  });
+
+  it("enterCinematic is idempotent when already cinematic", () => {
+    const { result } = renderHook(() => useSimulationMode());
+
+    act(() => {
+      result.current.enterCinematic("orbit");
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.mode).toBe("cinematic");
+    expect(result.current.cinematicVariant).toBe("orbit");
+
+    act(() => {
+      result.current.enterCinematic("dive");
+    });
+    expect(result.current.mode).toBe("cinematic");
+    expect(result.current.cinematicVariant).toBe("orbit");
+  });
+
+  it("enterInteractive is idempotent when already interactive", () => {
+    const { result } = renderHook(() => useSimulationMode());
+
+    act(() => {
+      result.current.enterInteractive();
+    });
+    expect(result.current.mode).toBe("interactive");
+  });
+});


### PR DESCRIPTION
Two commits closing the regression-test gap that audit zone 8 flagged:
bun run physics:regress used to match zero tests, and the rule's drift
threshold (1e-9 over 10^5 steps) lived in a comment.

Group 3A wires six Rust integration-test binaries against gravitas-core,
anchored to analytic Kerr orbit references. tests/common/mod.rs holds
the shared baselines: prograde and retrograde branches of Bardeen 1973
Eq. 28 (photon-sphere critical impact parameter) and Eq. 38 (Bardeen-
Press-Teukolsky ISCO), plus the standard regression spin grid mirroring
the EHT M87* and Sgr A* spin brackets.

- conservation.rs runs three 10^5-step integrations of an equatorial
  null ray at a* in {0, 0.5, 0.99} with adaptive RKF45; asserts the
  post-run E, L_z, Carter Q drift by less than 1e-9.
- photon_ring.rs pins photon_sphere() against the closed-form Bardeen
  formula across the spin grid plus the Schwarzschild and near-extremal
  limits.
- isco.rs locks both Kerr::isco branches against BPT closed-form across
  the spin grid; checks the Schwarzschild 6M coincidence and the
  near-extremal asymmetry.
- schwarzschild_degenerate.rs guards against future 1/a divisions: at
  a = 0 every Kerr-specific branch must collapse cleanly to the
  Schwarzschild form (r_+ = 2M, r_isco = 6M, r_ph = 3M, omega_ZAMO = 0,
  r_ergo = 2M independent of theta).
- near_extremal.rs is a 200-case proptest at a* = 0.99 across a wide
  spread of equatorial-ish initial conditions; the integrator must
  either escape, terminate cleanly, or surface NormalizationFailure
  within a 2000-step budget without producing NaN coordinates.

physics:regress in package.json now invokes cargo test --release across
all six binaries (the five new ones plus the SP-1 normalize.rs).

Group 3C lands three TypeScript test files locking the contracts the
renderer and worker rely on every frame. sab-schema.test.ts asserts
the offset arithmetic plus a property-based round-trip on byte offset
= f32 index times four. useSimulationMode.test.ts walks the three-state
mutex end to end under fake timers including the 500 ms transition
window and the idempotent-in-destination contract. useReducedMotion.test.ts
stubs window.matchMedia and verifies initial read, reactive flipping,
and listener cleanup on unmount.

Group 3B (Playwright + SSIM visual regression) and Group 3D (goldens
manifest + maintenance script) follow as separate PRs because they
need a dev-server boot harness and Playwright dep additions worth
their own review.

## Test plan

- [x] cd physics-engine && cargo test --release -p gravitas-core --tests (27 lib + 23 integration tests pass)
- [x] bun run physics:regress (alias now runs the real suite)
- [x] cd physics-engine && cargo clippy -p gravitas-core --tests -- -D warnings (clean)
- [x] bunx vitest run src/__tests__/engine/sab-schema.test.ts src/__tests__/hooks/useSimulationMode.test.ts src/__tests__/hooks/useReducedMotion.test.ts (16 pass)
- [x] bun run type-check (clean)