### PR TITLE
feat(sp4-4a): polarization primitives — Stokes + Walker-Penrose κ

### DIFF
--- a/physics-engine/gravitas-core/src/physics/mod.rs
+++ b/physics-engine/gravitas-core/src/physics/mod.rs
@@ -1,6 +1,7 @@
 //! Physical observables and astrophysical models.
 
 pub mod disk;
+pub mod polarization;
 pub mod redshift;
 pub mod shadow;
 pub mod spectrum;

--- a/physics-engine/gravitas-core/src/physics/polarization.rs
+++ b/physics-engine/gravitas-core/src/physics/polarization.rs
@@ -1,0 +1,269 @@
+//! Polarization primitives for null geodesics in Kerr spacetime.
+//!
+//! Three pieces. The [`StokesVector`] type carries the (I, Q, U, V)
+//! Stokes parameters along with helpers that preserve their geometric
+//! invariants. [`walker_penrose_kappa`] evaluates the Walker-Penrose
+//! constant κ_WP that Walker & Penrose (1970, *Commun. Math. Phys.* 18,
+//! 265, Eq. 2.3) showed is conserved along null geodesics in any
+//! type-D spacetime, including Kerr. [`evpa_rotation`] produces the
+//! electric-vector position-angle rotation Δχ between two evaluated
+//! κ_WP values; combined with [`StokesVector::rotate_evpa`] it is the
+//! transport law from emission to observation.
+//!
+//! What this module does *not* yet do: parallel-transport the
+//! polarization 4-vector f^μ along the geodesic. That requires
+//! extending the integrator to step (x, p, f) jointly using the
+//! parallel-transport equation Df^μ/dλ = 0. Until that lands, callers
+//! supply f^μ at both ends and this module composes the rotation; the
+//! invariant is the κ_WP value, not the raw f^μ.
+//!
+//! References:
+//! - Walker, M. & Penrose, R. (1970), "On Quadratic First Integrals
+//!   of the Geodesic Equations for Type [22] Spacetimes", *Commun.
+//!   Math. Phys.* 18, 265, Eq. 2.3.
+//! - Connors, P. A. & Stark, R. F. (1977), "Observable gravitational
+//!   effects on polarised radiation coming from near a black hole",
+//!   *Nature* 269, 128, Eq. 4-6.
+//! - Schnittman, J. D. & Krolik, J. H. (2009), "X-ray polarization
+//!   from accreting black holes: the thermal state", *ApJ* 701, 1175,
+//!   §2 for disk-emission Stokes initialization.
+
+use num_complex::Complex64;
+
+/// Stokes parameters describing a partially-polarised electromagnetic
+/// signal. Conventions follow IAU 1974: I is total intensity, Q and U
+/// describe linear polarisation (Q along the reference axis, U at 45°
+/// to it), and V describes circular polarisation (positive = right-
+/// handed when seen from the observer).
+///
+/// The physical constraints are I ≥ 0 and I² ≥ Q² + U² + V² (the
+/// degree of polarisation cannot exceed unity). Values that violate
+/// these are not rejected at construction; [`StokesVector::is_valid`]
+/// reports the constraint state explicitly.
+#[derive(Clone, Copy, Debug)]
+pub struct StokesVector {
+    /// Total intensity. Must be non-negative for physical signals.
+    pub i: f64,
+    /// Linear polarisation along the reference axis (Q = I_x - I_y).
+    pub q: f64,
+    /// Linear polarisation at 45° to the reference axis (U = I_a - I_b).
+    pub u: f64,
+    /// Circular polarisation (V = I_R - I_L).
+    pub v: f64,
+}
+
+impl StokesVector {
+    /// Unpolarised reference signal of unit intensity.
+    pub const UNPOLARISED_UNIT: Self = Self {
+        i: 1.0,
+        q: 0.0,
+        u: 0.0,
+        v: 0.0,
+    };
+
+    /// Construct from raw Stokes components.
+    #[must_use]
+    pub const fn new(i: f64, q: f64, u: f64, v: f64) -> Self {
+        Self { i, q, u, v }
+    }
+
+    /// Linear polarisation degree p_lin = sqrt(Q² + U²) / I.
+    /// Returns 0.0 when I is zero (no signal).
+    #[must_use]
+    pub fn linear_polarisation_degree(&self) -> f64 {
+        if self.i.abs() < f64::EPSILON {
+            0.0
+        } else {
+            self.q.hypot(self.u) / self.i
+        }
+    }
+
+    /// Total polarisation degree p = sqrt(Q² + U² + V²) / I.
+    #[must_use]
+    pub fn total_polarisation_degree(&self) -> f64 {
+        if self.i.abs() < f64::EPSILON {
+            0.0
+        } else {
+            (self.q * self.q + self.u * self.u + self.v * self.v).sqrt() / self.i
+        }
+    }
+
+    /// Electric-vector position angle (EVPA) χ = (1/2) atan2(U, Q),
+    /// measured in radians. Convention matches Connors+Stark 1977
+    /// Eq. 4: χ = 0 when the polarisation aligns with the reference
+    /// axis (positive Q). The factor 1/2 reflects that the Stokes Q,U
+    /// representation is double-valued in the polarisation plane.
+    #[must_use]
+    pub fn evpa(&self) -> f64 {
+        0.5 * self.u.atan2(self.q)
+    }
+
+    /// True iff I ≥ 0 and I² ≥ Q² + U² + V².
+    /// Strict equality holds for fully-polarised radiation.
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        if self.i.is_sign_negative() {
+            return false;
+        }
+        let p2 = self.q * self.q + self.u * self.u + self.v * self.v;
+        // Allow a small numerical slack (1e-12) so values produced by
+        // unitary rotations of fully-polarised input still pass.
+        p2 <= self.i * self.i * (1.0 + 1e-12)
+    }
+
+    /// Rotate the linear-polarisation plane by Δχ radians. Q and U
+    /// transform as a spin-2 quantity:
+    ///
+    ///   Q' = Q cos(2 Δχ) - U sin(2 Δχ)
+    ///   U' = Q sin(2 Δχ) + U cos(2 Δχ)
+    ///
+    /// I and V are invariant under this rotation. Returns a new
+    /// vector; the original is unchanged.
+    #[must_use]
+    pub fn rotate_evpa(self, delta_chi: f64) -> Self {
+        let two_chi = 2.0 * delta_chi;
+        let (sin2, cos2) = two_chi.sin_cos();
+        Self {
+            i: self.i,
+            q: self.q * cos2 - self.u * sin2,
+            u: self.q * sin2 + self.u * cos2,
+            v: self.v,
+        }
+    }
+}
+
+/// Walker-Penrose constant κ_WP for a null geodesic in Kerr spacetime.
+///
+/// The Walker-Penrose theorem (Walker & Penrose 1970, Eq. 2.3) states
+/// that the complex scalar
+///
+///   κ_WP = (A − i B)(r − i a cos θ)
+///
+/// with
+///
+///   A = (p^t f^r − p^r f^t) + a sin²θ (p^r f^φ − p^φ f^r)
+///   B = (r² + a²) (p^φ f^θ − p^θ f^φ) − a (p^t f^θ − p^θ f^t)
+///
+/// is invariant along any null geodesic with parallel-transported
+/// polarisation 4-vector f^μ. The expression is given here in the
+/// covariant Boyer-Lindquist tetrad and operates on the contravariant
+/// momentum components.
+///
+/// Inputs are
+/// - `position`: the four-position (t, r, θ, φ) in Boyer-Lindquist;
+///   only r and θ enter the formula.
+/// - `momentum_up`: the contravariant photon four-momentum p^μ.
+/// - `f_up`: the contravariant polarisation four-vector f^μ. The
+///   theorem assumes f is null and orthogonal to p; the function
+///   does not enforce that — see [`is_polarisation_orthogonal_to_momentum`].
+/// - `spin_a`: the geometric spin parameter a = a* M.
+///
+/// The return value is the unmodified κ_WP. Callers are expected to
+/// take its argument (`Complex64::arg`) when computing the EVPA
+/// rotation between two points along the geodesic.
+#[must_use]
+pub fn walker_penrose_kappa(
+    position: [f64; 4],
+    momentum_up: [f64; 4],
+    f_up: [f64; 4],
+    spin_a: f64,
+) -> Complex64 {
+    let r = position[1];
+    let theta = position[2];
+    let cos_theta = theta.cos();
+    let sin_theta = theta.sin();
+    let sin2_theta = sin_theta * sin_theta;
+    let a = spin_a;
+
+    let pt = momentum_up[0];
+    let pr = momentum_up[1];
+    let pth = momentum_up[2];
+    let pphi = momentum_up[3];
+
+    let ft = f_up[0];
+    let fr = f_up[1];
+    let fth = f_up[2];
+    let fphi = f_up[3];
+
+    let a_part = (pt * fr - pr * ft) + a * sin2_theta * (pr * fphi - pphi * fr);
+    let b_part = (r * r + a * a) * (pphi * fth - pth * fphi) - a * (pt * fth - pth * ft);
+
+    let scalar = Complex64::new(a_part, -b_part);
+    let rho = Complex64::new(r, -a * cos_theta);
+    scalar * rho
+}
+
+/// EVPA rotation Δχ induced by parallel transport from `kappa_emit`
+/// at the emission point to `kappa_obs` at the observation point.
+/// Walker & Penrose 1970 give κ_WP as conserved, so the difference in
+/// arg(κ_WP) between the two points is the rotation of the linear-
+/// polarisation plane in the chosen reference frame.
+///
+/// Returns 0.0 when either input has near-zero magnitude (treats the
+/// rotation as undefined; the caller should report I → 0 separately).
+#[must_use]
+pub fn evpa_rotation(kappa_emit: Complex64, kappa_obs: Complex64) -> f64 {
+    let mag_emit = kappa_emit.norm();
+    let mag_obs = kappa_obs.norm();
+    if mag_emit < f64::EPSILON || mag_obs < f64::EPSILON {
+        return 0.0;
+    }
+    (kappa_obs / kappa_emit).arg()
+}
+
+/// True iff the polarisation 4-vector f^μ is orthogonal to the
+/// photon 4-momentum p_μ (in the Lorentz-invariant inner product
+/// f^μ p_μ = 0). This is a precondition of the Walker-Penrose
+/// theorem; supplying a non-orthogonal pair gives a κ_WP value with
+/// no physical meaning.
+///
+/// `momentum_down` is the covariant momentum p_μ. The function does
+/// not require the metric to evaluate the inner product because we
+/// already have the index-lowered form.
+#[must_use]
+pub fn is_polarisation_orthogonal_to_momentum(
+    momentum_down: [f64; 4],
+    f_up: [f64; 4],
+    tolerance: f64,
+) -> bool {
+    let mut dot = 0.0;
+    for i in 0..4 {
+        dot += momentum_down[i] * f_up[i];
+    }
+    dot.abs() < tolerance
+}
+
+/// Initialise a Stokes vector at a thermal-disk emission point.
+/// Schnittman & Krolik 2009 §2 model: optically-thick thermal
+/// synchrotron from a magnetised disk produces linear polarisation
+/// with degree p_lin set by the local viewing geometry (Chandrasekhar
+/// 1960 limit ≈ 11.7 % at edge-on for pure scattering, lower for
+/// thermal). Circular polarisation V is negligible for thermal
+/// synchrotron and is set to zero.
+///
+/// The emitted EVPA is taken perpendicular to the local magnetic-
+/// field projection in the disk plane (`b_field_phi_angle` is the
+/// azimuth of B in radians). The caller supplies the local intensity
+/// `i_local` (already including g-factor scaling and emissivity) and
+/// the polarisation degree `p_lin` (the model parameter; values in
+/// [0, 0.117] for thermal, up to ~0.7 for power-law synchrotron).
+///
+/// The convention matches Schnittman+Krolik 2009 Eq. 5: positive Q
+/// means the EVPA aligns with the disk's azimuthal direction.
+#[must_use]
+pub fn initial_disk_stokes(
+    i_local: f64,
+    p_lin: f64,
+    b_field_phi_angle: f64,
+) -> StokesVector {
+    let p = p_lin.clamp(0.0, 1.0);
+    let chi = b_field_phi_angle + std::f64::consts::FRAC_PI_2;
+    let two_chi = 2.0 * chi;
+    let (sin2, cos2) = two_chi.sin_cos();
+    StokesVector {
+        i: i_local,
+        q: i_local * p * cos2,
+        u: i_local * p * sin2,
+        v: 0.0,
+    }
+}

--- a/physics-engine/gravitas-core/tests/polarization.rs
+++ b/physics-engine/gravitas-core/tests/polarization.rs
@@ -1,0 +1,325 @@
+//! Polarization primitives: Stokes vector algebra, Walker-Penrose
+//! constant invariants, and the EVPA rotation operator.
+//!
+//! What this suite proves:
+//! - Stokes invariants: I and V untouched by EVPA rotation, Q² + U²
+//!   preserved exactly (rotation is a 2D orthogonal map on (Q, U)).
+//! - rotate_evpa is unitary across the spin grid of test cases.
+//! - rotate_evpa(0) is the identity; rotate_evpa(π) is the identity
+//!   on physical Stokes (the (Q, U) double cover means a π rotation
+//!   in EVPA is a 2π rotation in (Q, U) space).
+//! - linear_polarisation_degree behaves as expected at boundaries.
+//! - Walker-Penrose κ has the correct linearity in f^μ and the
+//!   correct dependence on r and θ.
+//! - evpa_rotation returns Δarg between two κ values, with
+//!   degenerate inputs yielding 0.
+//! - The orthogonality predicate accepts orthogonal pairs and
+//!   rejects non-orthogonal pairs by tolerance.
+//! - Disk-emission init produces a vector with the requested
+//!   polarisation degree, perpendicular to the supplied B-field
+//!   azimuth (Schnittman+Krolik 2009 Eq. 5 sign convention).
+//!
+//! What it does *not* prove (out of scope this PR):
+//! - κ_WP conservation along an integrated null geodesic. That
+//!   requires extending the integrator to parallel-transport f^μ
+//!   alongside p^μ, which is a future change. The conservation is
+//!   theorem-level; the per-point evaluation is what this suite
+//!   exercises.
+
+use gravitas::physics::polarization::{
+    evpa_rotation, initial_disk_stokes, is_polarisation_orthogonal_to_momentum,
+    walker_penrose_kappa, StokesVector,
+};
+use num_complex::Complex64;
+use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI};
+
+const TIGHT: f64 = 1e-12;
+
+fn close(a: f64, b: f64) -> bool {
+    (a - b).abs() < TIGHT
+}
+
+// ---------------------------------------------------------------------
+// StokesVector algebra
+// ---------------------------------------------------------------------
+
+#[test]
+fn unpolarised_unit_has_zero_polarisation_degree() {
+    let s = StokesVector::UNPOLARISED_UNIT;
+    assert!(close(s.linear_polarisation_degree(), 0.0));
+    assert!(close(s.total_polarisation_degree(), 0.0));
+    assert!(s.is_valid());
+}
+
+#[test]
+fn fully_linear_polarised_has_degree_one() {
+    let s = StokesVector::new(1.0, 1.0, 0.0, 0.0);
+    assert!(close(s.linear_polarisation_degree(), 1.0));
+    assert!(s.is_valid());
+}
+
+#[test]
+fn evpa_zero_for_q_axis_polarised() {
+    let s = StokesVector::new(1.0, 0.5, 0.0, 0.0);
+    assert!(close(s.evpa(), 0.0));
+}
+
+#[test]
+fn evpa_quarter_pi_for_u_axis_polarised() {
+    let s = StokesVector::new(1.0, 0.0, 0.5, 0.0);
+    assert!(close(s.evpa(), FRAC_PI_4));
+}
+
+#[test]
+fn rotate_evpa_preserves_intensity_and_circular() {
+    let s = StokesVector::new(2.0, 0.4, 0.3, -0.1);
+    for &chi in &[0.0, 0.1, FRAC_PI_4, FRAC_PI_2, PI, -0.7] {
+        let r = s.rotate_evpa(chi);
+        assert!(close(r.i, s.i), "I changed after EVPA rotation by {chi}");
+        assert!(close(r.v, s.v), "V changed after EVPA rotation by {chi}");
+    }
+}
+
+#[test]
+fn rotate_evpa_preserves_linear_polarisation_magnitude() {
+    let s = StokesVector::new(1.0, 0.6, 0.2, 0.0);
+    let lin_before = s.q * s.q + s.u * s.u;
+    for &chi in &[0.05, 0.5, 1.3, 2.7, -0.4] {
+        let r = s.rotate_evpa(chi);
+        let lin_after = r.q * r.q + r.u * r.u;
+        assert!(
+            (lin_after - lin_before).abs() < 1e-13,
+            "Q² + U² drifted under rotation: {lin_before} → {lin_after}",
+        );
+    }
+}
+
+#[test]
+fn rotate_evpa_zero_is_identity() {
+    let s = StokesVector::new(1.5, 0.4, -0.1, 0.05);
+    let r = s.rotate_evpa(0.0);
+    assert!(close(r.i, s.i));
+    assert!(close(r.q, s.q));
+    assert!(close(r.u, s.u));
+    assert!(close(r.v, s.v));
+}
+
+#[test]
+fn rotate_evpa_pi_is_identity_on_qu() {
+    // π rotation in EVPA is a 2π rotation in (Q, U) space, so the
+    // physical state is identical to the input.
+    let s = StokesVector::new(1.0, 0.4, -0.2, 0.0);
+    let r = s.rotate_evpa(PI);
+    assert!((r.q - s.q).abs() < 1e-12);
+    assert!((r.u - s.u).abs() < 1e-12);
+}
+
+#[test]
+fn rotate_evpa_quarter_pi_swaps_q_into_minus_u() {
+    // EVPA rotation by π/4 corresponds to a (Q, U) rotation by π/2:
+    //   Q' = Q cos(π/2) - U sin(π/2) = -U
+    //   U' = Q sin(π/2) + U cos(π/2) = +Q
+    let s = StokesVector::new(1.0, 1.0, 0.0, 0.0);
+    let r = s.rotate_evpa(FRAC_PI_4);
+    assert!(r.q.abs() < 1e-12, "Q after π/4 EVPA rotation = {}", r.q);
+    assert!((r.u - 1.0).abs() < 1e-12, "U after π/4 EVPA rotation = {}", r.u);
+}
+
+#[test]
+fn linear_degree_is_zero_for_zero_intensity() {
+    let s = StokesVector::new(0.0, 0.0, 0.0, 0.0);
+    assert_eq!(s.linear_polarisation_degree(), 0.0);
+    assert_eq!(s.total_polarisation_degree(), 0.0);
+}
+
+#[test]
+fn negative_intensity_fails_validity() {
+    let s = StokesVector::new(-0.1, 0.0, 0.0, 0.0);
+    assert!(!s.is_valid());
+}
+
+#[test]
+fn over_polarised_state_fails_validity() {
+    // Q² + U² + V² > I² is unphysical.
+    let s = StokesVector::new(1.0, 1.0, 1.0, 1.0);
+    assert!(!s.is_valid());
+}
+
+// ---------------------------------------------------------------------
+// Walker-Penrose constant
+// ---------------------------------------------------------------------
+
+#[test]
+fn walker_penrose_is_linear_in_polarisation_vector() {
+    // κ_WP is bilinear in p^μ and f^μ; doubling f doubles κ.
+    let position = [0.0, 8.0, FRAC_PI_2, 0.0];
+    let momentum = [1.0, 0.05, 0.0, 0.04];
+    let f1 = [0.0, 0.1, 0.05, 0.02];
+    let f2 = [0.0, 0.2, 0.10, 0.04];
+    let spin = 0.5;
+
+    let k1 = walker_penrose_kappa(position, momentum, f1, spin);
+    let k2 = walker_penrose_kappa(position, momentum, f2, spin);
+    assert!((k2.re - 2.0 * k1.re).abs() < 1e-12);
+    assert!((k2.im - 2.0 * k1.im).abs() < 1e-12);
+}
+
+#[test]
+fn walker_penrose_vanishes_when_p_and_f_are_parallel() {
+    // If f^μ ∝ p^μ then every (p, f) pair in the formula is zero.
+    let position = [0.0, 6.0, FRAC_PI_2 - 0.1, 0.3];
+    let momentum = [1.0, 0.1, 0.05, 0.07];
+    let f_parallel = momentum;
+    let kappa = walker_penrose_kappa(position, momentum, f_parallel, 0.7);
+    assert!(kappa.norm() < 1e-12, "κ_WP should vanish for f ∝ p, got {kappa:?}");
+}
+
+#[test]
+fn walker_penrose_picks_up_imaginary_component_off_equator() {
+    // The (r − i a cos θ) factor produces a non-zero imaginary part
+    // whenever a ≠ 0 and θ ≠ π/2, even for a real-valued (A − i B).
+    let position_off = [0.0, 5.0, 0.7, 0.0];
+    let momentum = [1.0, 0.0, 0.1, 0.05];
+    let f_vec = [0.0, 0.2, 0.0, 0.0];
+    let kappa = walker_penrose_kappa(position_off, momentum, f_vec, 0.9);
+    assert!(kappa.im.abs() > 1e-9, "expected non-zero Im(κ) off equator");
+}
+
+#[test]
+fn walker_penrose_real_at_schwarzschild_equator_for_pr_only() {
+    // At a = 0, the (r − i a cos θ) factor is real (= r). Pick a
+    // momentum and f-vector so that the (A − i B) factor is also
+    // purely real (B = 0): set p^θ = f^θ = 0 and p^φ = f^φ = 0 so
+    // every cross term in B drops out.
+    let position = [0.0, 7.0, FRAC_PI_2, 0.0];
+    let momentum = [1.0, 0.1, 0.0, 0.0];
+    let f_vec = [0.5, 0.2, 0.0, 0.0];
+    let kappa = walker_penrose_kappa(position, momentum, f_vec, 0.0);
+    assert!(kappa.im.abs() < 1e-12, "expected real κ_WP, got {kappa:?}");
+}
+
+// ---------------------------------------------------------------------
+// EVPA rotation operator
+// ---------------------------------------------------------------------
+
+#[test]
+fn evpa_rotation_zero_when_kappa_unchanged() {
+    let kappa = Complex64::new(0.4, 0.7);
+    let chi = evpa_rotation(kappa, kappa);
+    assert!(close(chi, 0.0));
+}
+
+#[test]
+fn evpa_rotation_returns_phase_difference() {
+    let kappa_emit = Complex64::from_polar(2.0, 0.3);
+    let kappa_obs = Complex64::from_polar(1.5, 0.8);
+    let chi = evpa_rotation(kappa_emit, kappa_obs);
+    assert!(close(chi, 0.5));
+}
+
+#[test]
+fn evpa_rotation_handles_zero_magnitude_inputs() {
+    let kappa_emit = Complex64::new(0.0, 0.0);
+    let kappa_obs = Complex64::new(1.0, 0.5);
+    assert_eq!(evpa_rotation(kappa_emit, kappa_obs), 0.0);
+    assert_eq!(evpa_rotation(kappa_obs, kappa_emit), 0.0);
+}
+
+#[test]
+fn evpa_rotation_then_stokes_rotation_round_trip() {
+    // Composing the two primitives: feed the EVPA rotation back into
+    // the Stokes rotator; the result should be a unitary EVPA rotation
+    // by exactly that angle, leaving I and V untouched and preserving
+    // Q² + U².
+    let kappa_emit = Complex64::from_polar(1.0, 0.0);
+    let kappa_obs = Complex64::from_polar(1.0, 0.6);
+    let chi = evpa_rotation(kappa_emit, kappa_obs);
+    let s_emit = StokesVector::new(1.0, 0.5, 0.0, 0.05);
+    let s_obs = s_emit.rotate_evpa(chi);
+    let lin_in = s_emit.q.powi(2) + s_emit.u.powi(2);
+    let lin_out = s_obs.q.powi(2) + s_obs.u.powi(2);
+    assert!((lin_in - lin_out).abs() < 1e-13);
+    assert!(close(s_obs.i, s_emit.i));
+    assert!(close(s_obs.v, s_emit.v));
+}
+
+// ---------------------------------------------------------------------
+// Orthogonality predicate
+// ---------------------------------------------------------------------
+
+#[test]
+fn orthogonality_accepts_perpendicular_vectors() {
+    let p_down = [1.0, 0.0, 0.0, 0.0];
+    let f_up = [0.0, 1.0, 0.0, 0.0];
+    assert!(is_polarisation_orthogonal_to_momentum(p_down, f_up, 1e-9));
+}
+
+#[test]
+fn orthogonality_rejects_aligned_vectors() {
+    let p_down = [1.0, 0.5, 0.2, 0.1];
+    let f_up = [1.0, 0.5, 0.2, 0.1];
+    assert!(!is_polarisation_orthogonal_to_momentum(p_down, f_up, 1e-9));
+}
+
+#[test]
+fn orthogonality_respects_tolerance_for_small_inner_product() {
+    let p_down = [1.0, 0.0, 0.0, 0.0];
+    let f_up = [1e-12, 1.0, 0.0, 0.0];
+    assert!(is_polarisation_orthogonal_to_momentum(p_down, f_up, 1e-9));
+    assert!(!is_polarisation_orthogonal_to_momentum(p_down, f_up, 1e-15));
+}
+
+// ---------------------------------------------------------------------
+// Disk emission initialiser
+// ---------------------------------------------------------------------
+
+#[test]
+fn disk_emission_zero_intensity_yields_zero_stokes() {
+    let s = initial_disk_stokes(0.0, 0.5, 0.0);
+    assert_eq!(s.i, 0.0);
+    assert_eq!(s.q, 0.0);
+    assert_eq!(s.u, 0.0);
+    assert_eq!(s.v, 0.0);
+}
+
+#[test]
+fn disk_emission_zero_polarisation_yields_unpolarised_at_intensity() {
+    let s = initial_disk_stokes(2.5, 0.0, 1.234);
+    assert!(close(s.i, 2.5));
+    assert!(close(s.q, 0.0));
+    assert!(close(s.u, 0.0));
+    assert!(close(s.v, 0.0));
+}
+
+#[test]
+fn disk_emission_polarisation_degree_matches_input() {
+    let i = 1.0;
+    let p = 0.117; // Chandrasekhar 1960 thermal limit at edge-on
+    let s = initial_disk_stokes(i, p, 0.3);
+    assert!((s.linear_polarisation_degree() - p).abs() < 1e-12);
+    assert!(close(s.v, 0.0));
+}
+
+#[test]
+fn disk_emission_clamps_polarisation_to_unit_interval() {
+    // Inputs above 1.0 or below 0.0 are clamped silently; the output
+    // is still a valid Stokes vector.
+    let s_high = initial_disk_stokes(1.0, 1.5, 0.0);
+    let s_low = initial_disk_stokes(1.0, -0.1, 0.0);
+    assert!(s_high.is_valid());
+    assert!(s_low.is_valid());
+    assert!(close(s_high.linear_polarisation_degree(), 1.0));
+    assert!(close(s_low.linear_polarisation_degree(), 0.0));
+}
+
+#[test]
+fn disk_emission_evpa_perpendicular_to_b_field() {
+    // Schnittman+Krolik convention: the EVPA is at +π/2 to the local
+    // B-field azimuth. Setting B along φ = 0 should put the EVPA at
+    // π/2, which is the U axis (cos(π) = -1, sin(π) = 0; i.e., Q
+    // negative, U near zero).
+    let s = initial_disk_stokes(1.0, 0.5, 0.0);
+    // 2χ = π → cos(2χ) = -1, sin(2χ) = 0 → Q = -i*p, U = 0
+    assert!((s.q + 0.5).abs() < 1e-12, "Q should be -p, got {}", s.q);
+    assert!(s.u.abs() < 1e-12, "U should be 0, got {}", s.u);
+}


### PR DESCRIPTION
First PR of SP-4 (PhD physics fidelity uplift). Adds the per-point
polarization primitives needed for polarised radiative transfer in
Kerr spacetime: a Stokes vector type, a rigorous Walker-Penrose
constant evaluation per W&P 1970 Eq. 2.3, an EVPA rotation operator,
and a thermal-disk Stokes initialiser per Schnittman & Krolik 2009.

Scope is deliberately narrow: per-point primitives only. End-to-end
transport along an integrated geodesic requires extending the
integrator to parallel-transport the polarisation 4-vector f^μ
alongside the photon 4-momentum p^μ, and is its own change. Until
that lands, callers supply f^μ at both ends and this module composes
the rotation; the invariant is the κ_WP value, not the raw f^μ.

What ships:
- StokesVector with IAU 1974 conventions, derived quantities
  (linear/total polarisation degree, EVPA), and a unitary rotate_evpa
  that preserves I, V, and Q² + U² exactly.
- walker_penrose_kappa: W&P 1970 Eq. 2.3 evaluated in Boyer-Lindquist.
  Supersedes the existing constants_of_motion::walker_penrose stub
  (κ = ρ⁻¹ √Q) for new code; the stub stays for backward compat for
  one cycle and gets removed in a follow-up.
- evpa_rotation: composes two κ_WP values into Δχ.
- is_polarisation_orthogonal_to_momentum: f·p = 0 precondition with
  tunable tolerance.
- initial_disk_stokes: Schnittman+Krolik 2009 Eq. 5 sign convention,
  thermal synchrotron, V = 0, polarisation degree clamped to [0, 1].

Out of scope (deliberate, follow-up PRs):
- Integrator-level parallel transport of f^μ.
- WASM FFI surface for tick_sab_polarized.
- Shader-side compositing of Stokes hue/saturation.
- Control-panel toggle.
- The kerr_polarized.png golden in tests/golden/.

Test coverage: 28 new tests across the polarization integration
suite plus the existing gravitas-core test surface stays green.

## Test plan

- [x] cd physics-engine && cargo test -p gravitas-core --release --tests (74 tests pass: 23 lib + 51 across 7 integration test binaries)
- [x] cd physics-engine && cargo clippy -p gravitas-core --tests -- -D warnings (clean; pedantic + nursery still active)
- [x] cd physics-engine && cargo check -p gravitas-wasm (clean — new module is gravitas-core only, no WASM surface change)
- [x] bun run test (default vitest suite still green)
- [x] lefthook pre-commit + commit-msg + pre-push gates (run-tests passed in CI)

## Tests added (28 new)

Stokes algebra (10): unpolarised unit; fully linear; EVPA at Q-axis and U-axis; rotation preserves I + V; rotation preserves Q² + U²; rotation by 0 is identity; rotation by π is identity on (Q, U); rotation by π/4 swaps Q into U; zero-intensity returns zero degree; negative I and over-polarised states fail validity.

Walker-Penrose κ (4): linearity in f^μ; vanishing for f ∝ p; non-zero imaginary off-equator (Kerr a > 0, θ ≠ π/2); real-valued at Schwarzschild equator with p^θ = p^φ = 0.

EVPA rotation (4): zero when κ unchanged; arg-difference of polar inputs; degenerate inputs return 0 instead of NaN; round-trip with Stokes rotation preserves I, V, and Q² + U².

Orthogonality predicate (3): accepts perpendicular vectors; rejects aligned vectors; respects tolerance.

Disk emission (5): zero intensity zeroes everything; zero polarisation gives unpolarised at I; degree matches input; clamps above 1 and below 0; EVPA perpendicular to B-field per Schnittman+Krolik Eq. 5.

## What's NOT in this PR (false-claim guard)

- No claim of full geodesic-aware Stokes transport. The conservation
  of κ_WP along a null geodesic is theorem-level (W&P 1970); this PR
  does not run it through the integrator, so the κ_WP test that
  conservation along a propagated path is intentionally absent.
- No shader integration; no UI toggle; no FFI surface.
- The existing constants_of_motion::walker_penrose stub is left in
  place; new code should use the new surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Physics engine now includes polarization support, enabling Stokes vector calculations and detailed electromagnetic radiation property analysis.
  * Introduced new functions for computing, validating, and manipulating polarization properties and electromagnetic radiation transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->